### PR TITLE
Make contextMenu not visible by default

### DIFF
--- a/src/components/ImageZoomInOut.tsx
+++ b/src/components/ImageZoomInOut.tsx
@@ -19,7 +19,7 @@ const ImageZoomInOut: React.FC<ImageZoomInOutProps> = ({ imageUrl, menuItems }) 
 
     const [scale, setScale] = useState(1);
     const [position, setPosition] = useState({x:0,y:0});
-    const [contextMenu, setContextMenu] = useState({ visible: true, x: 0, y: 0, items: menuItems});
+    const [contextMenu, setContextMenu] = useState({ visible: false, x: 0, y: 0, items: menuItems});
 
     const imageRef = useRef<HTMLImageElement | null>(null);
 


### PR DESCRIPTION
Remove the temporary visual cue of contextMenu being visible by default